### PR TITLE
Update deprecated collections.MutableMapping

### DIFF
--- a/application/python/weakref.py
+++ b/application/python/weakref.py
@@ -1,7 +1,8 @@
 
 import weakref
 
-from collections import MutableMapping, deque
+from collections.abc import MutableMapping
+from collections import deque
 from copy import deepcopy
 from threading import local
 


### PR DESCRIPTION
`collections.MutableMapping` has been deprecated since Python 3.3 and finally removed in Python 3.10.

This PR replaces `collections.MutableMapping` with `collections.abc.MutableMapping`.